### PR TITLE
getAccountName に LIMIT を追加してパフォーマンス改善

### DIFF
--- a/golang/app.go
+++ b/golang/app.go
@@ -476,13 +476,7 @@ func getAccountName(w http.ResponseWriter, r *http.Request) {
 
 	results := []Post{}
 
-	err = db.Select(&results, `
-    SELECT id, user_id, body, mime, created_at
-    FROM posts
-    WHERE user_id = ?
-    ORDER BY created_at DESC
-    LIMIT 20
-	`, user.ID)
+	err = db.Select(&results, `SELECT id, user_id, body, mime, created_at FROM posts WHERE user_id = ? ORDER BY created_at DESC LIMIT 20`, user.ID)
 
 	if err != nil {
 		log.Print(err)

--- a/golang/app.go
+++ b/golang/app.go
@@ -476,7 +476,14 @@ func getAccountName(w http.ResponseWriter, r *http.Request) {
 
 	results := []Post{}
 
-	err = db.Select(&results, "SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = ? ORDER BY `created_at` DESC", user.ID)
+	err = db.Select(&results, `
+    SELECT id, user_id, body, mime, created_at
+    FROM posts
+    WHERE user_id = ?
+    ORDER BY created_at DESC
+    LIMIT 20
+	`, user.ID)
+
 	if err != nil {
 		log.Print(err)
 		return

--- a/golang/app.go
+++ b/golang/app.go
@@ -476,7 +476,14 @@ func getAccountName(w http.ResponseWriter, r *http.Request) {
 
 	results := []Post{}
 
-	err = db.Select(&results, `SELECT id, user_id, body, mime, created_at FROM posts WHERE user_id = ? ORDER BY created_at DESC LIMIT 20`, user.ID)
+	err = db.Select(&results, `
+    SELECT id, user_id, body, mime, created_at
+    FROM posts
+    WHERE user_id = ?
+    ORDER BY created_at DESC
+    LIMIT 20
+	`, user.ID)
+
 
 	if err != nil {
 		log.Print(err)


### PR DESCRIPTION
概要:
getAccountName 内の posts テーブルへのクエリに LIMIT 20 を追加しました。
これにより、該当ユーザーが多数の投稿を持つ場合でも、取得件数を制限し、レスポンスタイムとDB負荷を抑制します。

🔍 変更内容:
go
コピーする
編集する
err = db.Select(&results, `
    SELECT id, user_id, body, mime, created_at
    FROM posts
    WHERE user_id = ?
    ORDER BY created_at DESC
    LIMIT 20
`, user.ID)
🎯 意図・目的:
該当ユーザーの投稿が数百〜数千件に及ぶケースでのパフォーマンス劣化を回避

投稿ごとに関連情報（コメント・ユーザー情報）を取得する makePosts() の負荷を軽減（N+1の被害縮小）

フロントの表示数（postsPerPage = 20）に合わせて取得件数を統一し、UI上も過不足がない